### PR TITLE
Run Shellspec tests via GitHub Actions

### DIFF
--- a/.github/workflows/shellspec.yaml
+++ b/.github/workflows/shellspec.yaml
@@ -1,0 +1,24 @@
+---
+name: Shellspec Tests
+
+"on":
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+
+jobs:
+  Shellspec:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - uses: jerop/tkn@v0.1.0
+
+      - name: Shellspec
+        run: hack/test-shellspec.sh

--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ For quick local innerloop style task development, you may install new Tasks in y
 
 There is a container which is used to support multiple set of tasks called `quay.io/redhat-appstudio/appstudio-utils:GIT_SHA` , which is a single container which is used by multiple tasks. Tasks may also be in their own container as well however many simple tasks are utilities and will be packaged for app studio in a single container. Tasks can rely on other tasks in the system which are co-packed in a container allowing combined tasks (build-only vs build-deploy) which use the same core implementations.
 
+Shellspec tests can be run by invoking `hack/test-shellspec.sh`.
+
 ## Release
 
 Release is done by setting env variable `MY_QUAY_USER=redhat-appstudio`, `BUILD_TAG=$(git rev-parse HEAD)` and running `hack/build-and-push.sh`.

--- a/hack/shellspec/github_formatter.sh
+++ b/hack/shellspec/github_formatter.sh
@@ -1,0 +1,21 @@
+#shellcheck shell=bash disable=SC2154
+
+set -o errexit
+set -o pipefail
+set -o nounset
+
+print_error() {
+    message="${field_note}${field_note:+: }${field_message}%0A${field_failure_message//$'\n'/%0A}"
+    printf "::error file=%s,line=%d,endLine=%d,title=%s::%s%%0A" "${field_specfile}" "${field_lineno%-*}" "${field_lineno#*-}" "${field_message}" "${message}"
+}
+
+github_each() {
+    case "${field_type}" in
+        statement)
+            [[ "$field_fail" ]] && print_error
+            ;;
+        error)
+            print_error
+            ;;
+    esac
+}

--- a/hack/test-shellspec.sh
+++ b/hack/test-shellspec.sh
@@ -1,0 +1,39 @@
+#!/bin/env bash
+
+set -o errexit
+set -o pipefail
+set -o nounset
+
+ROOT="$(git rev-parse --show-toplevel)"
+
+# Run tests only for changed
+INCREMENTAL=${INCREMENTAL:-1}
+
+readarray SPEC_DIRS < <(find "${ROOT}" -name spec -type d -print0)
+
+REF=main
+if ! git rev-parse --verify main 2>/dev/null; then
+    REF=$(openssl rand -base64 12)
+fi
+git fetch origin "main:${REF}"
+readarray CHANGED_FILES < <(git diff .."${REF}" --name-only; git status --porcelain=v1 | cut -c 4-)
+
+for CHANGED in "${CHANGED_FILES[@]}"; do
+    CHANGED_DIR="${ROOT}/$(dirname "${CHANGED}")"
+    for SPEC_DIR in "${SPEC_DIRS[@]}"; do
+        # If the changed file is within the `spec` directory or the directory
+        # above it
+        if [[ "${CHANGED_DIR}" == "${SPEC_DIR}" || "${CHANGED_DIR}/spec" == "${SPEC_DIR}" ]]; then
+            SPEC_DIRS=("${SPEC_DIRS[@]/${SPEC_DIR}}")
+            [[ -n "${GITHUB_ACTIONS:-}" ]] && echo "::group::Shellspec test in ${SPEC_DIR}"
+            echo -e "Detected changes in \033[1m${CHANGED_DIR}\033[0m, running tests"
+            PARAMS=(--chdir "${SPEC_DIR}" --shell /usr/bin/bash)
+            [[ -n "${GITHUB_ACTIONS:-}" ]] && PARAMS+=(--format github -I "${ROOT}/hack/shellspec")
+            if ! command -v shellspec &> /dev/null; then
+                curl -fsSL https://git.io/shellspec | sh -s -- --yes
+            fi
+            shellspec "${PARAMS[@]}"
+            [[ -n "${GITHUB_ACTIONS:-}" ]] && echo '::endgroup::'
+        fi
+    done
+done

--- a/pipelines/enterprise-contract.yaml
+++ b/pipelines/enterprise-contract.yaml
@@ -50,11 +50,12 @@ spec:
           value: "$(params.SNAPSHOT)"
         - name: SSL_CERT_DIR
           value: "$(params.SSL_CERT_DIR)"
-        # Tekton only creates results for successful tasks. Since the goal of this pipeline
-        # is not to gate an operation, but to provide feedback to users, do not fail if there
-        # are violations. This ensures users can view the full validation report.
+        # It's confusing for users to see a passing taskrun that represents a failing EC test.
+        # For that reason let's have the taskrun fail when there are EC violations. Also, if
+        # this is set to false (IIUC), it's not possible to have the IntegrationTest gate the
+        # deploy to the devel environment work, which is what users expect to be able to do.
         - name: STRICT
-          value: "false"
+          value: "true"
         # Public Key should come from the Policy Configuration
         - name: PUBLIC_KEY
           value: ""

--- a/task/buildah/0.1/buildah.yaml
+++ b/task/buildah/0.1/buildah.yaml
@@ -119,7 +119,7 @@ spec:
         mv cachi2 /tmp/
         chmod -R go+rwX /tmp/cachi2
         VOLUME_MOUNTS="--volume /tmp/cachi2:/cachi2"
-        sed -i 's|^\s*run |RUN source /cachi2/cachi2.env \&\& \\\n    |i' "$dockerfile_path"
+        sed -i 's|^\s*run |RUN . /cachi2/cachi2.env \&\& \\\n    |i' "$dockerfile_path"
         echo "Prefetched content will be made available"
       fi
 

--- a/task/clair-scan/0.1/clair-scan.yaml
+++ b/task/clair-scan/0.1/clair-scan.yaml
@@ -20,6 +20,8 @@ spec:
   results:
     - name: HACBS_TEST_OUTPUT
       description: test output
+    - name: CLAIR_SCAN_RESULT
+      description: clair scan result
   steps:
     - name: get-vulnerabilities
       image: quay.io/redhat-appstudio/clair-in-ci:latest  # explicit floating tag, daily updates
@@ -54,8 +56,21 @@ spec:
       script: |
         #!/usr/bin/env bash
         . /utils.sh
-        HACBS_ERROR_OUTPUT=$(make_result_json -r "ERROR")
-        HACBS_TEST_OUTPUT=
-        parse_hacbs_test_output $(context.task.name) conftest /tekton/home/clair-vulnerabilities.json || true
 
-        echo "${HACBS_TEST_OUTPUT:-${HACBS_ERROR_OUTPUT}}" | tee $(results.HACBS_TEST_OUTPUT.path)
+        if [[ ! -f /tekton/home/clair-vulnerabilities.json ]] || [[ "$(jq '.[] | has("failures")' /tekton/home/clair-vulnerabilities.json)" == "false" ]]; then
+          HACBS_TEST_OUTPUT=$(make_result_json -r "ERROR" -t "/tekton/home/clair-vulnerabilities.json is not generated correctly, please check again")
+          echo "/tekton/home/clair-vulnerabilities.json is not generated correctly, please check again"
+          echo "${HACBS_TEST_OUTPUT}" | tee $(results.HACBS_TEST_OUTPUT.path)
+          exit 0
+        fi
+
+        jq -rce \
+          '{vulnerabilities:{
+              critical: (.[] | .failures | map(select(.metadata.details.name=="clair_critical_vulnerabilities")) | length),
+              high: (.[] | .failures | map(select(.metadata.details.name=="clair_high_vulnerabilities")) | length),
+              medium: (.[] | .failures | map(select(.metadata.details.name=="clair_medium_vulnerabilities")) | length),
+              low: (.[] | .failures | map(select(.metadata.details.name=="clair_low_vulnerabilities")) | length)
+            }}' /tekton/home/clair-vulnerabilities.json | tee $(results.CLAIR_SCAN_RESULT.path)
+
+        HACBS_TEST_OUTPUT=$(make_result_json -r "SUCCESS" -t "Please refer to result CLAIR_SCAN_RESULT for the vulnerabilities scanned by clair")
+        echo "${HACBS_TEST_OUTPUT}" | tee $(results.HACBS_TEST_OUTPUT.path)

--- a/task/fbc-validation/0.1/fbc-validation.yaml
+++ b/task/fbc-validation/0.1/fbc-validation.yaml
@@ -19,10 +19,13 @@ spec:
     - name: workspace
   steps:
     - name: extract-and-check-binaries
-      image: quay.io/redhat-appstudio/hacbs-test:v1.0.9@sha256:e3714c1ec1bd7bc754a510cba6892052a74bf523a185cf75a59d84059375444f
+      image: quay.io/redhat-appstudio/hacbs-test:v1.0.10@sha256:ae276785973aaffb4554c1798cf629df33e7058b30c32b75bd8ada54b2afe42f
       workingDir: $(workspaces.workspace.path)/hacbs/$(context.task.name)
       securityContext:
         runAsUser: 0
+        capabilities:
+          add:
+            - SETFCAP
       resources:
         limits:
           memory: 4Gi
@@ -32,9 +35,11 @@ spec:
           cpu: 10m
       script: |
         #!/usr/bin/env bash
+        set -o pipefail
         source /utils.sh
+
         ### Try to extract binaries with configs > check binaries functionality > check opm validate ###
-        if [ ! -f ../sanity-inspect-image/image_inspect.json ] || [ -z $(cat ../sanity-inspect-image/image_inspect.json) ]; then
+        if [ ! -s ../sanity-inspect-image/image_inspect.json ]; then
           echo "File ../sanity-inspect-image/image_inspect.json is not generated correctly, please check HACBS_TEST_OUTPUT of task sanity-inspect-image"
           HACBS_TEST_OUTPUT="$(make_result_json -r ERROR -t 'File ../sanity-inspect-image/image_inspect.json is not generated correctly, please check HACBS_TEST_OUTPUT of task sanity-inspect-image!')"
           echo "${HACBS_TEST_OUTPUT}" | tee $(results.HACBS_TEST_OUTPUT.path)
@@ -42,14 +47,29 @@ spec:
         fi
 
         conffolder=$(cat ../sanity-inspect-image/image_inspect.json | jq -r '.Labels ."operators.operatorframework.io.index.configs.v1"')
-
+        if [ $? -ne 0 ]; then
+          echo "Could not get labels from sanity-inspect-image/image_inspect.json, make sure the file exists and contains this label: operators.operatorframework.io.index.configs.v1."
+          HACBS_TEST_OUTPUT="$(make_result_json -r ERROR)"
+          echo "${HACBS_TEST_OUTPUT}" | tee "$(results.HACBS_TEST_OUTPUT.path)"
+          exit 0
+        fi
+        mkdir -p /tmp/image-content
+        pushd /tmp/image-content
         image_with_digest="$(params.IMAGE_URL)@$(params.IMAGE_DIGEST)"
 
-        mkdir confdir
-        if ! oc image extract "${image_with_digest}" --file /bin/opm --file /bin/grpc_health_probe --path $conffolder/*:confdir/ ; then
+        if ! oc image extract "${image_with_digest}" ; then
           echo "Unable to extract image! Skipping checking binaries!"
           HACBS_TEST_OUTPUT="$(make_result_json -r ERROR -t 'Unable to extract image! Skipping checking binaries!')"
           echo "${HACBS_TEST_OUTPUT}" | tee $(results.HACBS_TEST_OUTPUT.path)
+          popd
+          exit 0
+        fi
+
+        if [ -z "$(ls -A .$conffolder)" ]; then
+          echo "$conffolder is empty, missing catalog file."
+          HACBS_TEST_OUTPUT="$(make_result_json -r ERROR)"
+          echo "${HACBS_TEST_OUTPUT}" | tee "$(results.HACBS_TEST_OUTPUT.path)"
+          popd
           exit 0
         fi
 
@@ -57,24 +77,23 @@ spec:
         check_num=4
         failure_num=0
         TESTPASSED=true
-        chmod +x opm grpc_health_probe
 
-        if ! ./opm version; then
-          echo "!FAILURE! - opm binary check failed"
+        if [ ! $(find . -name "opm") ]; then
+          echo "!FAILURE! - opm binary presence check failed"
           failure_num=`expr $failure_num + 1`
           TESTPASSED=false
         fi
-        if [ ! -f "grpc_health_probe" ]; then
-          echo "!FAILURE! - grpc_health_probe binary check failed"
+        if [ ! $(find . -name grpc_health_probe ) ]; then
+          echo "!FAILURE! - grpc_health_probe binary presence check failed"
           failure_num=`expr $failure_num + 1`
           TESTPASSED=false
         fi
-        if ! ./opm validate confdir; then
+        if ! opm validate ."${conffolder}"; then
           echo "!FAILURE! - opm validate check has failed"
           failure_num=`expr $failure_num + 1`
           TESTPASSED=false
         fi
-        if ! ./opm render confdir | jq -en 'reduce (inputs | select(.schema == "olm.package")) as $obj (0; .+1) == 1'; then
+        if ! opm render ."${conffolder}" | jq -en 'reduce (inputs | select(.schema == "olm.package")) as $obj (0; .+1) == 1'; then
           echo "!FAILURE! - more than one olm.packages are not permitted in a FBC fragment"
           failure_num=`expr $failure_num + 1`
           TESTPASSED=false
@@ -86,3 +105,4 @@ spec:
           HACBS_TEST_OUTPUT="$(make_result_json -r SUCCESS -s $check_num)"
           echo "${HACBS_TEST_OUTPUT}" | tee $(results.HACBS_TEST_OUTPUT.path)
         fi
+        popd

--- a/task/sanity-label-check/0.1/sanity-label-check.yaml
+++ b/task/sanity-label-check/0.1/sanity-label-check.yaml
@@ -33,7 +33,7 @@ spec:
         #!/usr/bin/env bash
 
         . /utils.sh
-        if [ ! -f ../sanity-inspect-image/image_inspect.json ] || [ -z $(cat ../sanity-inspect-image/image_inspect.json) ]; then
+        if [ ! -s ../sanity-inspect-image/image_inspect.json ]; then
           echo "File ../sanity-inspect-image/image_inspect.json is not generated correctly, please check HACBS_TEST_OUTPUT of task sanity-inspect-image"
           HACBS_TEST_OUTPUT="$(make_result_json -r ERROR -t 'File ../sanity-inspect-image/image_inspect.json is not generated correctly, please check HACBS_TEST_OUTPUT of task sanity-inspect-image!')"
           echo "${HACBS_TEST_OUTPUT}" | tee $(results.HACBS_TEST_OUTPUT.path)

--- a/task/tkn-bundle/0.1/spec/support/task_run_subject.sh
+++ b/task/tkn-bundle/0.1/spec/support/task_run_subject.sh
@@ -9,11 +9,11 @@ shellspec_syntax 'shellspec_subject_taskrun'
 shellspec_subject_taskrun() {
   # shellcheck disable=SC2034
   SHELLSPEC_META='text'
-  shellspec_readfile_once SHELLSPEC_STDOUT "$SHELLSPEC_STDOUT_FILE"
+  SHELLSPEC_STDOUT=$(<"${SHELLSPEC_STDOUT_FILE}")
   if [ ${SHELLSPEC_STDOUT+x} ]; then
-    # shellcheck disable=SC2034
-    LINES=(${SHELLSPEC_STDOUT[@]})
+    IFS=" " read -r -a LINES <<< "${SHELLSPEC_STDOUT}"
     TASK_RUN_NAME="${LINES[2]}" # "TaskRun(0) started:(1) tkn-bundle-run-ndjfb(2)
+    # shellcheck disable=SC2034
     SHELLSPEC_SUBJECT="$(tkn tr describe "${TASK_RUN_NAME}" -o json)"
     shellspec_chomp SHELLSPEC_SUBJECT
   else

--- a/task/tkn-bundle/0.1/spec/tkn-bundle_spec.sh
+++ b/task/tkn-bundle/0.1/spec/tkn-bundle_spec.sh
@@ -10,7 +10,17 @@ Describe "tkn-bundle task"
   setup() {
     # Create Kind cluster if it doesn't exist already
     CLUSTER_NAME="test-tkn-bundle"
-    kind get clusters -q | grep -q "${CLUSTER_NAME}" || kind create cluster -q --name="${CLUSTER_NAME}"
+    if ! command -v kind &> /dev/null; then
+      curl https://i.jpillora.com/kubernetes-sigs/kind | bash
+      mv kind "$HOME/.local/bin"
+    fi
+    kind get clusters -q | grep -q "${CLUSTER_NAME}" || kind create cluster -q --name="${CLUSTER_NAME}" || { echo 'ERROR: Unable to create a kind cluster'; return 1; }
+    kubectl cluster-info 2>&1 || { echo 'ERROR: Failed to access the cluster'; return 1; }
+
+    if ! command -v kubectl &> /dev/null; then
+      echo "ERROR: Please install kubectl"
+      return 1
+    fi
 
     # Install Tekton Pipeline, proceed with the rest of the test of the setup
     kubectl apply -f https://storage.googleapis.com/tekton-releases/pipeline/previous/v0.42.0/release.yaml


### PR DESCRIPTION
The test we have in `task/tkn-bundle/0.1/spec` is now exercised on
GitHub Actions by running `hack/test-shellspec.sh`. There is support for
GitHub reporting via annotations and incremental test runs -- i.e. skip
running change-unrelated tests.

Ref. https://issues.redhat.com/browse/HACBS-1740