### PR TITLE
Simplifies the incremental test

### DIFF
--- a/hack/test-shellspec.sh
+++ b/hack/test-shellspec.sh
@@ -11,12 +11,18 @@ INCREMENTAL=${INCREMENTAL:-1}
 
 readarray SPEC_DIRS < <(find "${ROOT}" -name spec -type d -print0)
 
-REF=main
-if ! git rev-parse --verify main 2>/dev/null; then
-    REF=$(openssl rand -base64 12)
-fi
-git fetch origin "main:${REF}"
-readarray CHANGED_FILES < <(git diff .."${REF}" --name-only; git status --porcelain=v1 | cut -c 4-)
+REF=temp-$(openssl rand -base64 12)
+git fetch origin "${GITHUB_BASE_REF:-main}:${REF}" >/dev/null 2>&1
+function cleanup() {
+    # shellcheck disable=SC2317
+    git branch --delete "${REF}" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+readarray CHANGED_FILES < <(git diff "${GITHUB_SHA:-}".."${REF}" --name-only; git status --porcelain=v1 | cut -c 4-)
+
+echo "${CHANGED_FILES[@]}"
+
+exit 0
 
 for CHANGED in "${CHANGED_FILES[@]}"; do
     CHANGED_DIR="${ROOT}/$(dirname "${CHANGED}")"


### PR DESCRIPTION
This removes the `git fetch` and assumes that `main` will be up to date.