### PR TITLE
Adapts the incremental support for GitHub

### DIFF
--- a/.github/workflows/shellspec.yaml
+++ b/.github/workflows/shellspec.yaml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       - uses: jerop/tkn@v0.1.0
 

--- a/hack/test-shellspec.sh
+++ b/hack/test-shellspec.sh
@@ -11,12 +11,18 @@ INCREMENTAL=${INCREMENTAL:-1}
 
 readarray SPEC_DIRS < <(find "${ROOT}" -name spec -type d -print0)
 
-REF=main
-if ! git rev-parse --verify main 2>/dev/null; then
-    REF=$(openssl rand -base64 12)
-fi
-git fetch origin "main:${REF}"
-readarray CHANGED_FILES < <(git diff .."${REF}" --name-only; git status --porcelain=v1 | cut -c 4-)
+REF=temp-$(openssl rand -base64 12)
+git fetch origin "${GITHUB_BASE_REF:-main}:${REF}" >/dev/null 2>&1
+function cleanup() {
+    # shellcheck disable=SC2317
+    git branch --delete "${REF}" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+readarray CHANGED_FILES < <({ if [[ -n "${GITHUB_ACTIONS:-}" ]]; then git diff HEAD~1 --name-only; else git diff .."${REF}" --name-only; git status --porcelain=v1 | cut -c 4-; fi; }| uniq)
+
+echo "${CHANGED_FILES[@]}"
+
+exit 0
 
 for CHANGED in "${CHANGED_FILES[@]}"; do
     CHANGED_DIR="${ROOT}/$(dirname "${CHANGED}")"


### PR DESCRIPTION
The script no longer fetches into `main` but to a temp branch. This should fix the:

```
fatal: refusing to fetch into branch 'refs/heads/main' checked out at '/home/runner/work/build-definitions/build-definitions'
```

error.

The script now takes into account running on GitHub Actions and takes the relevant git change commit id and base from the available environment variables.